### PR TITLE
Add NextAuth login and Mongo utility

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -1,0 +1,32 @@
+import NextAuth from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { compare } from 'bcrypt'
+import clientPromise from '@/utils/mongo'
+
+export const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        const client = await clientPromise
+        const user = await client.db().collection('users').findOne({ email: credentials.email })
+        if (user && await compare(credentials.password, user.password)) {
+          return { id: user._id.toString(), email: user.email }
+        }
+        return null
+      }
+    })
+  ],
+  session: { strategy: 'jwt' },
+  pages: {
+    signIn: '/login',
+    error: '/login-failed'
+  }
+}
+
+const handler = NextAuth(authOptions)
+export { handler as GET, handler as POST }

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -1,0 +1,15 @@
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '../api/auth/[...nextauth]/route'
+import { redirect } from 'next/navigation'
+
+export default async function Dashboard() {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    redirect('/login')
+  }
+  return (
+    <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',minHeight:'calc(100vh - 120px)'}}>
+      <h1>Ora sei nella dashboard</h1>
+    </div>
+  )
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -4,6 +4,7 @@ import "./styles/main.css";
 import "./styles/buttons.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import AuthProvider from "@/components/AuthProvider";
 
 const poppins = Poppins({
   variable: "--font-poppins",
@@ -25,9 +26,11 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={`${poppins.variable} ${geistMono.variable}`}>
-        <Navbar items={[{ label: 'Home', href: '/' }, { label: 'Contatti', href: '/contatti' }]} />
-        {children}
-        <Footer />
+        <AuthProvider>
+          <Navbar items={[{ label: 'Home', href: '/' }, { label: 'Contatti', href: '/contatti' }]} />
+          {children}
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/login-failed/page.js
+++ b/app/login-failed/page.js
@@ -1,0 +1,10 @@
+export const metadata = { title: 'Login Fallito' }
+
+export default function LoginFailed() {
+  return (
+    <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',minHeight:'calc(100vh - 120px)'}}>
+      <h1>Login fallito</h1>
+      <p>Controlla le credenziali e riprova.</p>
+    </div>
+  )
+}

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,0 +1,27 @@
+'use client'
+import { signIn } from 'next-auth/react'
+import styles from './page.module.css'
+
+export default function Login() {
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    await signIn('credentials', {
+      redirect: true,
+      callbackUrl: '/dashboard',
+      email: formData.get('email'),
+      password: formData.get('password')
+    })
+  }
+
+  return (
+    <div className={styles.login}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <input type="email" name="email" placeholder="Email" required />
+        <input type="password" name="password" placeholder="Password" required />
+        <button type="submit" className="btn">Entra</button>
+      </form>
+    </div>
+  )
+}

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -1,0 +1,26 @@
+.login {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 120px);
+  text-align: center;
+  gap: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 280px;
+}
+
+input {
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+button {
+  border: none;
+}

--- a/components/AuthProvider.js
+++ b/components/AuthProvider.js
@@ -1,0 +1,6 @@
+'use client'
+import { SessionProvider } from 'next-auth/react'
+
+export default function AuthProvider({ children }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,9 +1,12 @@
 'use client';
 import Link from 'next/link';
+import { useSession, signOut } from 'next-auth/react';
 import styles from './Navbar.module.css';
 import '../app/styles/buttons.css';
 
 export default function Navbar({ items = [] }) {
+  const { data: session } = useSession();
+
   return (
     <nav className={styles.nav}>
       <ul className={styles.menu}>
@@ -16,6 +19,15 @@ export default function Navbar({ items = [] }) {
             )}
           </li>
         ))}
+        {session ? (
+          <li className={styles.item}>
+            <button onClick={() => signOut({ callbackUrl: '/' })} className={styles.link}>Logout</button>
+          </li>
+        ) : (
+          <li className={styles.item}>
+            <Link href="/login" className={styles.link}>Login</Link>
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.5"
+    "next": "15.3.5",
+    "next-auth": "^4.24.5",
+    "bcrypt": "^5.1.1",
+    "mongodb": "^6.5.0"
   }
 }

--- a/utils/mongo.js
+++ b/utils/mongo.js
@@ -1,0 +1,18 @@
+import { MongoClient } from 'mongodb'
+
+const uri = process.env.MONGODB_URI
+
+if (!uri) {
+  throw new Error('Please define the MONGODB_URI environment variable')
+}
+
+let client
+let clientPromise
+
+if (!global._mongoClientPromise) {
+  client = new MongoClient(uri)
+  global._mongoClientPromise = client.connect()
+}
+clientPromise = global._mongoClientPromise
+
+export default clientPromise


### PR DESCRIPTION
## Summary
- add NextAuth credentials provider and Mongo helper
- create login, login failed and dashboard pages
- show Login/Logout in the navbar based on session
- wrap the layout with an auth provider
- document new dependencies

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701273ce44832fa29289fc8c8fbf94