### PR TITLE
Fix CSS module issue and add dashboard layout

### DIFF
--- a/app/contatti/page.js
+++ b/app/contatti/page.js
@@ -1,4 +1,3 @@
-import '@/app/styles/buttons.css';
 import styles from './page.module.css';
 import { InstagramIcon, TwitterIcon, TikTokIcon } from '@/components/Icons';
 

--- a/app/dashboard/layout.js
+++ b/app/dashboard/layout.js
@@ -1,0 +1,9 @@
+export const metadata = { title: 'Dashboard' };
+
+export default function DashboardLayout({ children }) {
+  return (
+    <section style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',minHeight:'calc(100vh - 120px)'}}>
+      {children}
+    </section>
+  );
+}

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -8,8 +8,8 @@ export default async function Dashboard() {
     redirect('/login')
   }
   return (
-    <div style={{display:'flex',flexDirection:'column',alignItems:'center',justifyContent:'center',minHeight:'calc(100vh - 120px)'}}>
+    <>
       <h1>Ora sei nella dashboard</h1>
-    </div>
+    </>
   )
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -2,6 +2,7 @@ import { Poppins, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "./styles/main.css";
 import "./styles/buttons.css";
+import "./styles/forms.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AuthProvider from "@/components/AuthProvider";

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -14,13 +14,3 @@
   gap: 1rem;
   width: 280px;
 }
-
-:global(input) {
-  padding: 0.5rem;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-}
-
-:global(button) {
-  border: none;
-}

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,3 @@
-import '@/app/styles/buttons.css';
 import styles from './page.module.css';
 
 export default function Home() {
@@ -8,6 +7,9 @@ export default function Home() {
       <p className={styles.description}>
         Questa pagina parla di se stessa. Serve come segnaposto mentre
         costruiamo il sito definitivo.
+      </p>
+      <p className={styles.description}>
+        Continua a seguirci per scoprire tutte le novità che stiamo preparando.
       </p>
       <button className="btn">Un semplice bottone</button>
     </div>

--- a/app/styles/forms.css
+++ b/app/styles/forms.css
@@ -1,0 +1,9 @@
+input {
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+button {
+  border: none;
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -2,7 +2,6 @@
 import Link from 'next/link';
 import { useSession, signOut } from 'next-auth/react';
 import styles from './Navbar.module.css';
-import '../app/styles/buttons.css';
 
 export default function Navbar({ items = [] }) {
   const { data: session } = useSession();


### PR DESCRIPTION
## Summary
- move global input/button styles to `forms.css`
- update root layout to import the new global styles
- clean up `Login` CSS module and remove redundant imports
- add an extra paragraph on the home page
- create a dedicated layout for the dashboard page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870170690f8832fbac4e4635ac19274