### PR TITLE
Avoid build failure from missing Mongo env var

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -1,7 +1,6 @@
 import NextAuth from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { compare } from 'bcrypt'
-import clientPromise from '@/utils/mongo'
 
 export const authOptions = {
   providers: [
@@ -12,6 +11,7 @@ export const authOptions = {
         password: { label: 'Password', type: 'password' }
       },
       async authorize(credentials) {
+        const { default: clientPromise } = await import('@/utils/mongo')
         const client = await clientPromise
         const user = await client.db().collection('users').findOne({ email: credentials.email })
         if (user && await compare(credentials.password, user.password)) {


### PR DESCRIPTION
## Summary
- avoid importing the mongo connection during build

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701ced86b8832fb66eaa9d13b7d95b