### PR TITLE
Implement user model for login

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -1,27 +1,40 @@
 import NextAuth from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { compare } from 'bcrypt'
+import { findUserByUsername } from '@/models/User'
 
 export const authOptions = {
   providers: [
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        email: { label: 'Email', type: 'email' },
+        user: { label: 'User', type: 'text' },
         password: { label: 'Password', type: 'password' }
       },
       async authorize(credentials) {
-        const { default: clientPromise } = await import('@/utils/mongo')
-        const client = await clientPromise
-        const user = await client.db().collection('users').findOne({ email: credentials.email })
+        const user = await findUserByUsername(credentials.user)
         if (user && await compare(credentials.password, user.password)) {
-          return { id: user._id.toString(), email: user.email }
+          return { id: user._id.toString(), user: user.user, role: user.role }
         }
         return null
       }
     })
   ],
   session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = user.role
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.role = token.role
+      }
+      return session
+    }
+  },
   pages: {
     signIn: '/login',
     error: '/login-failed'

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -8,7 +8,7 @@ export default function Login() {
     await signIn('credentials', {
       redirect: true,
       callbackUrl: '/dashboard',
-      email: formData.get('email'),
+      user: formData.get('user'),
       password: formData.get('password')
     })
   }
@@ -17,7 +17,7 @@ export default function Login() {
     <div className="login">
       <h1>Login</h1>
       <form onSubmit={handleSubmit} className="form">
-        <input type="email" name="email" placeholder="Email" required />
+        <input type="text" name="user" placeholder="User" required />
         <input type="password" name="password" placeholder="Password" required />
         <button type="submit" className="btn">Entra</button>
       </form>

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,6 @@
+import clientPromise from '@/utils/mongo'
+
+export async function findUserByUsername(username) {
+  const client = await clientPromise
+  return client.db().collection('users').findOne({ user: username })
+}


### PR DESCRIPTION
## Summary
- add `User` model to centralize user lookup
- update credentials provider to use model and expose user role
- surface role inside JWT/session via callbacks
- adjust login page to use `user` field

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702153b0c8832f8d1ec9bb299737e8