### PR TITLE
Improve theme toggle and footer styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,14 +8,14 @@
 
 @media (prefers-color-scheme: light) {
   :root {
-    --background: #ffffff;
-    --foreground: #171717;
+    --background: #f5f5f5;
+    --foreground: #333333;
   }
 }
 
 html[data-theme='light'] {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f5f5f5;
+  --foreground: #333333;
   color-scheme: light;
 }
 

--- a/app/styles/footer.css
+++ b/app/styles/footer.css
@@ -17,7 +17,7 @@
   width: 100%;
   border-top: 2px dashed var(--color-primary);
   transform: scaleX(0);
-  transform-origin: left;
+  transform-origin: center;
   transition: transform 0.3s ease;
 }
 
@@ -31,13 +31,14 @@
   font-size: 1.5rem;
 }
 
-.icons a {
-  color: inherit;
-  transition: color 0.3s ease;
+.icons .btn {
+  border-color: var(--color-white);
+  color: var(--color-white);
 }
 
-.icons a:hover {
-  color: var(--color-primary);
+.icons .btn:hover {
+  border-color: var(--color-black);
+  color: var(--color-black);
 }
 
 .copy {

--- a/app/styles/pages.css
+++ b/app/styles/pages.css
@@ -31,7 +31,12 @@
   width: 280px;
 }
 
-.contact .icons .btn:hover svg {
-  fill: var(--color-black);
-  stroke: var(--color-black);
+.contact .icons .btn {
+  border-color: var(--color-white);
+  color: var(--color-white);
+}
+
+.contact .icons .btn:hover {
+  border-color: var(--color-black);
+  color: var(--color-black);
 }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -4,9 +4,15 @@ export default function Footer() {
   return (
     <footer className="footer">
       <div className="icons">
-        <a href="#" aria-label="Instagram"><InstagramIcon /></a>
-        <a href="#" aria-label="Twitter"><TwitterIcon /></a>
-        <a href="#" aria-label="TikTok"><TikTokIcon /></a>
+        <a href="#" className="btn" aria-label="Instagram">
+          <InstagramIcon />
+        </a>
+        <a href="#" className="btn" aria-label="Twitter">
+          <TwitterIcon />
+        </a>
+        <a href="#" className="btn" aria-label="TikTok">
+          <TikTokIcon />
+        </a>
       </div>
       <span className="copy">evolve srls</span>
     </footer>

--- a/components/Icons.js
+++ b/components/Icons.js
@@ -23,3 +23,47 @@ export function TikTokIcon(props) {
     </svg>
   );
 }
+
+export function SunIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+export function MoonIcon(props) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { SunIcon, MoonIcon } from './Icons'
 
 export default function ThemeToggle() {
   const [theme, setTheme] = useState('dark')
@@ -26,7 +27,7 @@ export default function ThemeToggle() {
 
   return (
     <button onClick={toggle} className="link" aria-label="Toggle theme">
-      {theme === 'dark' ? '🌞' : '🌜'}
+      {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- add Sun and Moon icons
- switch theme toggle to SVG icons
- fine-tune light theme colors
- expand footer dashed line from center
- refine button hover styles in contact and footer
- reuse social buttons in footer

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870245c795c832f9720314d7f23dc56