### PR TITLE
Fix missing MongoDB URI build error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env.local and provide your Mongo connection string
+MONGODB_URI=mongodb://localhost:27017/mydatabase

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pnpm dev
 # or
 bun dev
 ```
-
+Before starting the server remember to configure the required environment variables. Copy `.env.example` to `.env.local` and update `MONGODB_URI` with your Mongo connection string.
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.

--- a/models/User.js
+++ b/models/User.js
@@ -1,6 +1,5 @@
-import clientPromise from '@/utils/mongo'
-
 export async function findUserByUsername(username) {
+  const { default: clientPromise } = await import('@/utils/mongo')
   const client = await clientPromise
   return client.db().collection('users').findOne({ user: username })
 }


### PR DESCRIPTION
## Summary
- use dynamic mongo import in user model
- document MongoDB environment variable requirement
- provide example environment file
- allow committing `.env.example`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68702530ae68832fa63b9d648bc2f98b