### PR TITLE
Fix metadata export for game page

### DIFF
--- a/app/game/layout.js
+++ b/app/game/layout.js
@@ -1,0 +1,5 @@
+export const metadata = { title: 'Game' };
+
+export default function GameLayout({ children }) {
+  return <>{children}</>;
+}

--- a/app/game/page.js
+++ b/app/game/page.js
@@ -1,9 +1,5 @@
 import Game from '@/components/Game'
 
-export const metadata = {
-  title: 'Game'
-}
-
 export default function GamePage() {
   return <Game />
 }


### PR DESCRIPTION
## Summary
- fix metadata usage under `/game` by moving it to a layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702a475260832f97797d66e706dffd