### PR TITLE
Refine navbar and footer, redesign game area

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -7,6 +7,7 @@ import "./styles/navbar.css";
 import "./styles/footer.css";
 import "./styles/pages.css";
 import "./styles/icons.css";
+import "./styles/game.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AuthProvider from "@/components/AuthProvider";

--- a/app/styles/game.css
+++ b/app/styles/game.css
@@ -1,0 +1,21 @@
+.game {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  height: calc(100vh - 120px);
+}
+
+.game-canvas {
+  width: 100%;
+  max-width: 800px;
+  flex-grow: 1;
+  background: var(--color-black);
+  border: 2px solid var(--color-primary);
+  border-radius: 8px;
+}
+
+.randomize-btn {
+  margin-top: 1rem;
+}

--- a/app/styles/icons.css
+++ b/app/styles/icons.css
@@ -12,4 +12,5 @@
 .icons .btn:hover {
   border-color: var(--color-primary);
   color: var(--color-black);
+  background: var(--color-primary);
 }

--- a/app/styles/navbar.css
+++ b/app/styles/navbar.css
@@ -4,8 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(6px);
+  background: var(--color-black);
   position: sticky;
   top: 0;
   z-index: 10;

--- a/components/Game.js
+++ b/components/Game.js
@@ -1,25 +1,41 @@
 'use client'
 import { useRef, useEffect, useState } from 'react'
 
+const shipIcons = ['/ship.svg', '/vercel.svg', '/window.svg']
+const alienIcons = ['/alien1.svg', '/alien2.svg', '/alien3.svg', '/next.svg', '/file.svg']
+
 export default function Game() {
   const canvasRef = useRef(null)
+  const shipImgRef = useRef(new Image())
+  const [shipIcon, setShipIcon] = useState(shipIcons[0])
   const [score, setScore] = useState(0)
+
+  const randomizeIcons = () => {
+    const next = shipIcons[Math.floor(Math.random() * shipIcons.length)]
+    setShipIcon(next)
+  }
+
+  useEffect(() => {
+    shipImgRef.current.src = shipIcon
+  }, [shipIcon])
 
   useEffect(() => {
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
     let animationId
     const width = (canvas.width = canvas.offsetWidth)
-    const height = (canvas.height = 400)
+    const height = (canvas.height = canvas.offsetHeight)
 
-    const ship = { x: width / 2 - 20, y: height - 30, width: 40, height: 20 }
+    const ship = { x: width / 2 - 20, y: height - 40, width: 40, height: 40 }
     const bullets = []
     const aliens = []
     let left = false
     let right = false
 
     const spawnAlien = () => {
-      aliens.push({ x: Math.random() * (width - 30), y: -20, size: 30 })
+      const img = new Image()
+      img.src = alienIcons[Math.floor(Math.random() * alienIcons.length)]
+      aliens.push({ x: Math.random() * (width - 40), y: -40, size: 40, img })
     }
 
     let spawnInterval = setInterval(spawnAlien, 1000)
@@ -92,11 +108,11 @@ export default function Game() {
       ctx.fillStyle = '#000'
       ctx.fillRect(0, 0, width, height)
 
-      ctx.fillStyle = '#39FF14'
-      ctx.fillRect(ship.x, ship.y, ship.width, ship.height)
+      ctx.drawImage(shipImgRef.current, ship.x, ship.y, ship.width, ship.height)
 
+      ctx.fillStyle = '#39FF14'
       bullets.forEach(b => ctx.fillRect(b.x, b.y, b.width, b.height))
-      aliens.forEach(a => ctx.fillRect(a.x, a.y, a.size, a.size))
+      aliens.forEach(a => ctx.drawImage(a.img, a.x, a.y, a.size, a.size))
 
       animationId = requestAnimationFrame(update)
     }
@@ -118,6 +134,7 @@ export default function Game() {
       <h1 className="title">Game</h1>
       <div>Score: {score}</div>
       <canvas ref={canvasRef} className="game-canvas" />
+      <button onClick={randomizeIcons} className="btn randomize-btn">Randomizza Icone</button>
     </div>
   )
 }

--- a/public/alien1.svg
+++ b/public/alien1.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+  <circle cx="12" cy="12" r="8"/>
+  <circle cx="9" cy="10" r="1.5" fill="#000"/>
+  <circle cx="15" cy="10" r="1.5" fill="#000"/>
+  <path d="M8 16c2 1.5 6 1.5 8 0" stroke="#000" stroke-width="2" fill="none"/>
+</svg>

--- a/public/alien2.svg
+++ b/public/alien2.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+  <rect x="4" y="4" width="16" height="16" rx="3"/>
+  <circle cx="9" cy="10" r="1.5" fill="#000"/>
+  <circle cx="15" cy="10" r="1.5" fill="#000"/>
+  <path d="M8 16h8" stroke="#000" stroke-width="2"/>
+</svg>

--- a/public/alien3.svg
+++ b/public/alien3.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+  <path d="M12 2L20 8v8l-8 6-8-6V8z"/>
+  <circle cx="9" cy="12" r="1.2" fill="#000"/>
+  <circle cx="15" cy="12" r="1.2" fill="#000"/>
+</svg>

--- a/public/ship.svg
+++ b/public/ship.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#fff">
+  <path d="M12 2 L18 22 L12 18 L6 22 Z"/>
+</svg>


### PR DESCRIPTION
## Summary
- keep navbar dark in light mode
- fill footer icons with green on hover
- introduce dedicated game styles
- draw game using svg icons and add randomize button
- bundle new game assets

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702cf8639c832f84e428b51094f030