### PR TITLE
Add Magazzino link to navbar

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -45,6 +45,7 @@ export default function RootLayout({ children }) {
               { label: 'Home', href: '/' },
               { label: 'Contatti', href: '/contatti' },
               { label: 'Game', href: '/game' },
+              { label: 'Magazzino', href: '/magazzino' },
             ]}
           />
           {children}


### PR DESCRIPTION
## Summary
- add the Magazzino page to the global Navbar

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687039066900832fa8eab5f51cfee087