### PR TITLE
Implement Evolve themed pages with team section

### DIFF
--- a/app/chi-siamo/page.js
+++ b/app/chi-siamo/page.js
@@ -1,0 +1,25 @@
+import FounderCard from '@/components/FounderCard'
+
+export const metadata = {
+  title: 'Chi Siamo'
+}
+
+const founders = [
+  { name: 'Luca', description: 'Appassionato di tecnologia e nuove sfide.' },
+  { name: 'Sara', description: 'Esperta di stampa 3D e design.' },
+  { name: 'Marco', description: 'Si occupa di consulenza software.' },
+  { name: 'Giulia', description: 'Coordina i progetti con creatività.' }
+]
+
+export default function ChiSiamo() {
+  return (
+    <div className="about">
+      <h1 className="title">Chi Siamo</h1>
+      <div className="founders">
+        {founders.map((f, idx) => (
+          <FounderCard key={idx} name={f.name} description={f.description} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/contatti/page.js
+++ b/app/contatti/page.js
@@ -9,8 +9,8 @@ export default function Contatti() {
     <div className="contact">
       <h1 className="title">Contattaci</h1>
       <p className="description">
-        Questa pagina sa di essere solo un segnaposto narrativo. Se vuoi parlarne,
-        scegli pure un social.
+        Vuoi saperne di più? Scrivici a infoevolvecompany@gmail.com o seguici sui
+        nostri social.
       </p>
       <div className="icons">
         <a href="#" className="btn" aria-label="Instagram"><InstagramIcon /></a>

--- a/app/layout.js
+++ b/app/layout.js
@@ -9,6 +9,7 @@ import "./styles/pages.css";
 import "./styles/icons.css";
 import "./styles/game.css";
 import "./styles/magazzino.css";
+import "./styles/about.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AuthProvider from "@/components/AuthProvider";
@@ -43,6 +44,7 @@ export default function RootLayout({ children }) {
           <Navbar
             items={[
               { label: 'Home', href: '/' },
+              { label: 'Chi Siamo', href: '/chi-siamo' },
               { label: 'Contatti', href: '/contatti' },
               { label: 'Game', href: '/game' },
               { label: 'Magazzino', href: '/magazzino' },

--- a/app/page.js
+++ b/app/page.js
@@ -2,15 +2,17 @@
 export default function Home() {
   return (
     <div className="home">
-      <h1 className="title">Benvenuto sulla homepage</h1>
+      <h1 className="title">Benvenuto in Evolve</h1>
       <p className="description">
-        Questa pagina parla di se stessa. Serve come segnaposto mentre
-        costruiamo il sito definitivo.
+        Evolve è una società di consulenza informatica e stampa 3D. Offriamo
+        supporto nello sviluppo software, nella gestione di infrastrutture e
+        nella realizzazione di prototipi e produzioni personalizzate tramite la
+        stampa tridimensionale.
       </p>
       <p className="description">
-        Continua a seguirci per scoprire tutte le novità che stiamo preparando.
+        Scopri come i nostri servizi possono aiutarti a dare forma alle tue idee
+        e ottimizzare i processi della tua azienda.
       </p>
-      <button className="btn">Un semplice bottone</button>
     </div>
   );
 }

--- a/app/styles/about.css
+++ b/app/styles/about.css
@@ -1,0 +1,83 @@
+.about {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem 0;
+  min-height: calc(100vh - 120px);
+}
+
+.founders {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.founder-card {
+  width: 180px;
+  height: 240px;
+  perspective: 1000px;
+}
+
+.founder-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.founder-card:hover .founder-inner {
+  transform: rotateY(180deg);
+}
+
+.founder-face {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border: 1px solid var(--color-primary);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.founder-front {
+  background: var(--color-black);
+  color: var(--color-white);
+}
+
+.founder-front img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: opacity 0.6s;
+}
+
+.founder-card:hover .founder-front img {
+  opacity: 0.4;
+}
+
+.founder-name {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  text-align: center;
+  padding: 0.25rem 0;
+  font-weight: bold;
+}
+
+.founder-back {
+  background: var(--color-black);
+  color: var(--color-white);
+  transform: rotateY(180deg);
+  padding: 1rem;
+  text-align: center;
+}

--- a/app/styles/pages.css
+++ b/app/styles/pages.css
@@ -1,6 +1,7 @@
 .home,
 .contact,
-.login {
+.login,
+.about {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -14,7 +14,8 @@ export default function Footer() {
           <TikTokIcon />
         </a>
       </div>
-      <span className="copy">evolve srls</span>
+      <span className="copy">Evolve SRLS - P.IVA 12345678901</span>
+      <span className="copy">infoevolvecompany@gmail.com</span>
     </footer>
   );
 }

--- a/components/FounderCard.js
+++ b/components/FounderCard.js
@@ -1,0 +1,21 @@
+'use client'
+import Image from 'next/image'
+
+const placeholder = '/avatar-placeholder.svg'
+
+export default function FounderCard({ name, image = placeholder, description }) {
+  const imgSrc = image || placeholder
+  return (
+    <div className="founder-card">
+      <div className="founder-inner">
+        <div className="founder-face founder-front">
+          <Image src={imgSrc} alt={name} fill />
+          <span className="founder-name">{name}</span>
+        </div>
+        <div className="founder-face founder-back">
+          <p>{description}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/public/avatar-placeholder.svg
+++ b/public/avatar-placeholder.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#222">
+  <circle cx="12" cy="7" r="5"/>
+  <path d="M2 22c0-5.5 4.5-8 10-8s10 2.5 10 8H2z"/>
+</svg>


### PR DESCRIPTION
## Summary
- update homepage with info on Evolve services
- update contact page with company email
- extend footer with P.IVA and email
- add 'Chi Siamo' page with founder cards
- create founder card component and styles
- import new styles and navigation entry

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703bb905d0832f8f2fa5e5e76eddbf