### PR TITLE
Add finance chart page

### DIFF
--- a/app/entrate-uscite/mockup.json
+++ b/app/entrate-uscite/mockup.json
@@ -1,0 +1,8 @@
+[
+  {"mese": "Gennaio", "tipo": "entrata", "descrizione": "Vendita prototipi 3D", "importo": 3500},
+  {"mese": "Gennaio", "tipo": "uscita", "descrizione": "Acquisto filamenti", "importo": 1200},
+  {"mese": "Febbraio", "tipo": "entrata", "descrizione": "Consulenza software", "importo": 2800},
+  {"mese": "Febbraio", "tipo": "uscita", "descrizione": "Manutenzione stampanti", "importo": 800},
+  {"mese": "Marzo", "tipo": "entrata", "descrizione": "Nuovi ordini stampa 3D", "importo": 4200},
+  {"mese": "Marzo", "tipo": "uscita", "descrizione": "Marketing online", "importo": 1500}
+]

--- a/app/entrate-uscite/page.js
+++ b/app/entrate-uscite/page.js
@@ -1,0 +1,15 @@
+import FinanceChart from '@/components/FinanceChart'
+import records from './mockup.json'
+
+export const metadata = {
+  title: 'Entrate e Uscite',
+}
+
+export default function EntrateUscitePage() {
+  return (
+    <div className="bilancio">
+      <h1 className="title">Entrate/Uscite</h1>
+      <FinanceChart records={records} />
+    </div>
+  )
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -10,6 +10,7 @@ import "./styles/icons.css";
 import "./styles/game.css";
 import "./styles/magazzino.css";
 import "./styles/about.css";
+import "./styles/finanze.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AuthProvider from "@/components/AuthProvider";
@@ -48,6 +49,7 @@ export default function RootLayout({ children }) {
               { label: 'Contatti', href: '/contatti' },
               { label: 'Game', href: '/game' },
               { label: 'Magazzino', href: '/magazzino' },
+              { label: 'Entrate/Uscite', href: '/entrate-uscite' },
             ]}
           />
           {children}

--- a/app/styles/finanze.css
+++ b/app/styles/finanze.css
@@ -1,0 +1,52 @@
+.bilancio {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 0;
+  min-height: calc(100vh - 120px);
+}
+
+.finance-chart {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  height: 200px;
+  border-bottom: 1px solid var(--foreground);
+}
+
+.bar {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bar-inner {
+  width: 100%;
+  height: var(--h, 50%);
+  background: var(--color-primary);
+  border-radius: 4px 4px 0 0;
+  transition: height 0.3s ease;
+}
+
+.bar.expense .bar-inner {
+  background: var(--color-white);
+  transform: scaleY(-1);
+  transform-origin: bottom;
+  border-radius: 0 0 4px 4px;
+}
+
+.bar-label {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  text-align: center;
+}

--- a/components/FinanceChart.js
+++ b/components/FinanceChart.js
@@ -1,0 +1,60 @@
+'use client'
+import { useState } from 'react'
+
+const months = [
+  'Gennaio',
+  'Febbraio',
+  'Marzo',
+  'Aprile',
+  'Maggio',
+  'Giugno',
+  'Luglio',
+  'Agosto',
+  'Settembre',
+  'Ottobre',
+  'Novembre',
+  'Dicembre',
+]
+
+export default function FinanceChart({ records = [] }) {
+  const [monthIdx, setMonthIdx] = useState(0)
+  const currentMonth = months[monthIdx]
+  const filtered = records.filter(r => r.mese === currentMonth)
+  const max = Math.max(...filtered.map(r => r.importo), 1)
+
+  return (
+    <div className="finance-chart">
+      <div
+        className="filter-slider"
+        style={{ '--slider-pct': `${(monthIdx / (months.length - 1)) * 100}%` }}
+      >
+        <input
+          type="range"
+          min="0"
+          max={months.length - 1}
+          step="1"
+          value={monthIdx}
+          onChange={e => setMonthIdx(Number(e.target.value))}
+        />
+        <div className="labels">
+          {months.map(m => (
+            <span key={m}>{m.slice(0, 3)}</span>
+          ))}
+        </div>
+      </div>
+
+      <div className="chart">
+        {filtered.map((rec, idx) => {
+          const height = `${(rec.importo / max) * 100}%`
+          const barClass = rec.tipo === 'entrata' ? 'income' : 'expense'
+          return (
+            <div key={idx} className={`bar ${barClass}`}>
+              <div className="bar-inner" style={{ '--h': height }} />
+              <small className="bar-label">{rec.descrizione}</small>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create FinanceChart component with month filter and bar chart
- add styles for finance page
- add Entrate/Uscite page with mockup data
- include new page in navbar

## Testing
- `npx next lint` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687040203a98832fa506de8c9dd0363e