### PR TITLE
Add pie charts and improve finance chart

### DIFF
--- a/app/entrate-uscite/page.js
+++ b/app/entrate-uscite/page.js
@@ -1,4 +1,5 @@
 import FinanceChart from '@/components/FinanceChart'
+import PieChart from '@/components/PieChart'
 import records from './mockup.json'
 
 export const metadata = {
@@ -10,6 +11,10 @@ export default function EntrateUscitePage() {
     <div className="bilancio">
       <h1 className="title">Entrate/Uscite</h1>
       <FinanceChart records={records} />
+      <div className="pie-charts">
+        <PieChart records={records} type="entrata" title="Entrate per mese" />
+        <PieChart records={records} type="uscita" title="Uscite per mese" />
+      </div>
     </div>
   )
 }

--- a/app/styles/finanze.css
+++ b/app/styles/finanze.css
@@ -16,21 +16,37 @@
 }
 
 .chart {
+  position: relative;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 1rem;
   height: 200px;
-  border-bottom: 1px solid var(--foreground);
+}
+
+.chart::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: var(--foreground);
 }
 
 .bar {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100%;
 }
 
 .bar-inner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 50%;
   width: 100%;
   height: var(--h, 50%);
   background: var(--color-primary);
@@ -39,9 +55,9 @@
 }
 
 .bar.expense .bar-inner {
+  top: 50%;
+  bottom: auto;
   background: var(--color-white);
-  transform: scaleY(-1);
-  transform-origin: bottom;
   border-radius: 0 0 4px 4px;
 }
 
@@ -49,4 +65,25 @@
   margin-top: 0.25rem;
   font-size: 0.8rem;
   text-align: center;
+}
+
+.pie-charts {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.pie-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pie-chart {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 1px solid var(--foreground);
 }

--- a/components/PieChart.js
+++ b/components/PieChart.js
@@ -1,0 +1,50 @@
+'use client'
+import React from 'react'
+
+const months = [
+  'Gennaio',
+  'Febbraio',
+  'Marzo',
+  'Aprile',
+  'Maggio',
+  'Giugno',
+  'Luglio',
+  'Agosto',
+  'Settembre',
+  'Ottobre',
+  'Novembre',
+  'Dicembre',
+]
+
+const colors = [
+  '#ff6384', '#36a2eb', '#cc65fe', '#ffce56', '#4bc0c0', '#9966ff',
+  '#c9cbcf', '#ff9f40', '#ffcd56', '#4dc9f6', '#b4b4b4', '#f67019'
+]
+
+export default function PieChart({ records = [], type = 'entrata', title }) {
+  const totals = months.map(m =>
+    records
+      .filter(r => r.mese === m && r.tipo === type)
+      .reduce((sum, r) => sum + r.importo, 0)
+  )
+  const totalSum = totals.reduce((s, v) => s + v, 0)
+
+  let startDeg = 0
+  const segments = totals.map((t, i) => {
+    const pct = totalSum ? (t / totalSum) * 360 : 0
+    const end = startDeg + pct
+    const segment = `${colors[i % colors.length]} ${startDeg}deg ${end}deg`
+    startDeg = end
+    return segment
+  })
+  const gradient = segments.length
+    ? `conic-gradient(${segments.join(',')})`
+    : 'none'
+
+  return (
+    <div className="pie-wrapper">
+      {title && <h2 className="subtitle">{title}</h2>}
+      <div className="pie-chart" style={{ background: gradient }} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- enhance Entrate/Uscite chart by centering the axis and fixing bar direction
- add a reusable PieChart component
- show monthly income and expense pies on Entrate/Uscite page
- style new charts

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687043758e58832f901aaefc3e241bef