### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/styles/about.css
+++ b/app/styles/about.css
@@ -81,3 +81,14 @@
   padding: 1rem;
   text-align: center;
 }
+
+@media (max-width: 480px) {
+  .founders {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .founder-card {
+    width: 160px;
+    height: 220px;
+  }
+}

--- a/app/styles/finanze.css
+++ b/app/styles/finanze.css
@@ -87,3 +87,10 @@
   border-radius: 50%;
   border: 1px solid var(--foreground);
 }
+
+@media (max-width: 480px) {
+  .pie-chart {
+    width: 100px;
+    height: 100px;
+  }
+}

--- a/app/styles/footer.css
+++ b/app/styles/footer.css
@@ -29,3 +29,10 @@
 .copy {
   font-size: 0.875rem;
 }
+
+@media (max-width: 480px) {
+  .footer {
+    padding: 1rem 0;
+    gap: 0.5rem;
+  }
+}

--- a/app/styles/forms.css
+++ b/app/styles/forms.css
@@ -19,3 +19,9 @@ html[data-theme='light'] input {
 button {
   border: none;
 }
+
+@media (max-width: 480px) {
+  input {
+    width: 100%;
+  }
+}

--- a/app/styles/game.css
+++ b/app/styles/game.css
@@ -59,3 +59,16 @@
   background: var(--color-primary);
   width: 100%;
 }
+
+@media (max-width: 480px) {
+  .game-overlay {
+    padding: 0.25rem;
+    gap: 0.25rem;
+  }
+  .game .title {
+    font-size: 1.25rem;
+  }
+  .health-bar {
+    width: 80px;
+  }
+}

--- a/app/styles/magazzino.css
+++ b/app/styles/magazzino.css
@@ -127,3 +127,12 @@
   border: none;
   font-size: 1rem;
 }
+
+@media (max-width: 480px) {
+  .magazzino {
+    padding: 1rem 0;
+  }
+  .inventory-list {
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  }
+}

--- a/app/styles/navbar.css
+++ b/app/styles/navbar.css
@@ -80,3 +80,12 @@
     align-items: center;
   }
 }
+
+@media (max-width: 480px) {
+  .nav {
+    padding: 0.75rem 1rem;
+  }
+  .link {
+    font-size: 0.95rem;
+  }
+}

--- a/app/styles/pages.css
+++ b/app/styles/pages.css
@@ -26,3 +26,16 @@
   gap: 1rem;
   width: 280px;
 }
+
+@media (max-width: 480px) {
+  .title {
+    font-size: 2rem;
+  }
+  .description {
+    padding: 0 1rem;
+  }
+  .login .form {
+    width: 100%;
+    max-width: 280px;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak navbar layout for small screens
- scale down fonts and forms for phones
- shrink game overlay elements
- adjust about page founder cards for narrow viewports
- make magazzino and finances pages mobile friendly
- reduce footer spacing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687044aa1364832fb2f2d25b2336103d