### PR TITLE
Enhance finance charts

### DIFF
--- a/app/entrate-uscite/mockup.json
+++ b/app/entrate-uscite/mockup.json
@@ -3,288 +3,504 @@
     "mese": "Gennaio",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 3763
+    "importo": 3763,
+    "data": "2024-01-05"
   },
   {
     "mese": "Gennaio",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 1765
+    "importo": 1765,
+    "data": "2024-01-12"
   },
   {
     "mese": "Gennaio",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2737
+    "importo": 2737,
+    "data": "2024-01-18"
   },
   {
     "mese": "Gennaio",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1492
+    "importo": 1492,
+    "data": "2024-01-22"
+  },
+  {
+    "mese": "Gennaio",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 500,
+    "data": "2024-01-26"
+  },
+  {
+    "mese": "Gennaio",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 250,
+    "data": "2024-01-28"
   },
   {
     "mese": "Febbraio",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 2844
+    "importo": 2844,
+    "data": "2024-02-05"
   },
   {
     "mese": "Febbraio",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 2928
+    "importo": 2928,
+    "data": "2024-02-12"
   },
   {
     "mese": "Febbraio",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2198
+    "importo": 2198,
+    "data": "2024-02-18"
   },
   {
     "mese": "Febbraio",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1801
+    "importo": 1801,
+    "data": "2024-02-22"
+  },
+  {
+    "mese": "Febbraio",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 600,
+    "data": "2024-02-26"
+  },
+  {
+    "mese": "Febbraio",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 300,
+    "data": "2024-02-28"
   },
   {
     "mese": "Marzo",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 3336
+    "importo": 3336,
+    "data": "2024-03-05"
   },
   {
     "mese": "Marzo",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 3789
+    "importo": 3789,
+    "data": "2024-03-12"
   },
   {
     "mese": "Marzo",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2533
+    "importo": 2533,
+    "data": "2024-03-18"
   },
   {
     "mese": "Marzo",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1329
+    "importo": 1329,
+    "data": "2024-03-22"
+  },
+  {
+    "mese": "Marzo",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 700,
+    "data": "2024-03-26"
+  },
+  {
+    "mese": "Marzo",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 350,
+    "data": "2024-03-28"
   },
   {
     "mese": "Aprile",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 4610
+    "importo": 4610,
+    "data": "2024-04-05"
   },
   {
     "mese": "Aprile",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 3741
+    "importo": 3741,
+    "data": "2024-04-12"
   },
   {
     "mese": "Aprile",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2795
+    "importo": 2795,
+    "data": "2024-04-18"
   },
   {
     "mese": "Aprile",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 705
+    "importo": 705,
+    "data": "2024-04-22"
+  },
+  {
+    "mese": "Aprile",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 800,
+    "data": "2024-04-26"
+  },
+  {
+    "mese": "Aprile",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 400,
+    "data": "2024-04-28"
   },
   {
     "mese": "Maggio",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 4049
+    "importo": 4049,
+    "data": "2024-05-05"
   },
   {
     "mese": "Maggio",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 1735
+    "importo": 1735,
+    "data": "2024-05-12"
   },
   {
     "mese": "Maggio",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1441
+    "importo": 1441,
+    "data": "2024-05-18"
   },
   {
     "mese": "Maggio",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1655
+    "importo": 1655,
+    "data": "2024-05-22"
+  },
+  {
+    "mese": "Maggio",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 900,
+    "data": "2024-05-26"
+  },
+  {
+    "mese": "Maggio",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 450,
+    "data": "2024-05-28"
   },
   {
     "mese": "Giugno",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 4128
+    "importo": 4128,
+    "data": "2024-06-05"
   },
   {
     "mese": "Giugno",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 1510
+    "importo": 1510,
+    "data": "2024-06-12"
   },
   {
     "mese": "Giugno",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1954
+    "importo": 1954,
+    "data": "2024-06-18"
   },
   {
     "mese": "Giugno",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1237
+    "importo": 1237,
+    "data": "2024-06-22"
+  },
+  {
+    "mese": "Giugno",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1000,
+    "data": "2024-06-26"
+  },
+  {
+    "mese": "Giugno",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 500,
+    "data": "2024-06-28"
   },
   {
     "mese": "Luglio",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 2803
+    "importo": 2803,
+    "data": "2024-07-05"
   },
   {
     "mese": "Luglio",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 2179
+    "importo": 2179,
+    "data": "2024-07-12"
   },
   {
     "mese": "Luglio",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1281
+    "importo": 1281,
+    "data": "2024-07-18"
   },
   {
     "mese": "Luglio",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1716
+    "importo": 1716,
+    "data": "2024-07-22"
+  },
+  {
+    "mese": "Luglio",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1100,
+    "data": "2024-07-26"
+  },
+  {
+    "mese": "Luglio",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 550,
+    "data": "2024-07-28"
   },
   {
     "mese": "Agosto",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 3019
+    "importo": 3019,
+    "data": "2024-08-05"
   },
   {
     "mese": "Agosto",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 3976
+    "importo": 3976,
+    "data": "2024-08-12"
   },
   {
     "mese": "Agosto",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1039
+    "importo": 1039,
+    "data": "2024-08-18"
   },
   {
     "mese": "Agosto",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 763
+    "importo": 763,
+    "data": "2024-08-22"
+  },
+  {
+    "mese": "Agosto",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1200,
+    "data": "2024-08-26"
+  },
+  {
+    "mese": "Agosto",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 600,
+    "data": "2024-08-28"
   },
   {
     "mese": "Settembre",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 3471
+    "importo": 3471,
+    "data": "2024-09-05"
   },
   {
     "mese": "Settembre",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 2988
+    "importo": 2988,
+    "data": "2024-09-12"
   },
   {
     "mese": "Settembre",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2927
+    "importo": 2927,
+    "data": "2024-09-18"
   },
   {
     "mese": "Settembre",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 831
+    "importo": 831,
+    "data": "2024-09-22"
+  },
+  {
+    "mese": "Settembre",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1300,
+    "data": "2024-09-26"
+  },
+  {
+    "mese": "Settembre",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 650,
+    "data": "2024-09-28"
   },
   {
     "mese": "Ottobre",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 2941
+    "importo": 2941,
+    "data": "2024-10-05"
   },
   {
     "mese": "Ottobre",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 2728
+    "importo": 2728,
+    "data": "2024-10-12"
   },
   {
     "mese": "Ottobre",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1216
+    "importo": 1216,
+    "data": "2024-10-18"
   },
   {
     "mese": "Ottobre",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1315
+    "importo": 1315,
+    "data": "2024-10-22"
+  },
+  {
+    "mese": "Ottobre",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1400,
+    "data": "2024-10-26"
+  },
+  {
+    "mese": "Ottobre",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 700,
+    "data": "2024-10-28"
   },
   {
     "mese": "Novembre",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 3022
+    "importo": 3022,
+    "data": "2024-11-05"
   },
   {
     "mese": "Novembre",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 2434
+    "importo": 2434,
+    "data": "2024-11-12"
   },
   {
     "mese": "Novembre",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 1825
+    "importo": 1825,
+    "data": "2024-11-18"
   },
   {
     "mese": "Novembre",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 1285
+    "importo": 1285,
+    "data": "2024-11-22"
+  },
+  {
+    "mese": "Novembre",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1500,
+    "data": "2024-11-26"
+  },
+  {
+    "mese": "Novembre",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 750,
+    "data": "2024-11-28"
   },
   {
     "mese": "Dicembre",
     "tipo": "entrata",
     "descrizione": "Vendita prodotti",
-    "importo": 4107
+    "importo": 4107,
+    "data": "2024-12-05"
   },
   {
     "mese": "Dicembre",
     "tipo": "entrata",
     "descrizione": "Consulenza",
-    "importo": 1978
+    "importo": 1978,
+    "data": "2024-12-12"
   },
   {
     "mese": "Dicembre",
     "tipo": "uscita",
     "descrizione": "Spese operative",
-    "importo": 2356
+    "importo": 2356,
+    "data": "2024-12-18"
   },
   {
     "mese": "Dicembre",
     "tipo": "uscita",
     "descrizione": "Marketing",
-    "importo": 904
+    "importo": 904,
+    "data": "2024-12-22"
+  },
+  {
+    "mese": "Dicembre",
+    "tipo": "entrata",
+    "descrizione": "Progetto extra",
+    "importo": 1600,
+    "data": "2024-12-26"
+  },
+  {
+    "mese": "Dicembre",
+    "tipo": "uscita",
+    "descrizione": "Varie",
+    "importo": 800,
+    "data": "2024-12-28"
   }
 ]

--- a/app/entrate-uscite/page.js
+++ b/app/entrate-uscite/page.js
@@ -1,16 +1,22 @@
 import FinanceChart from '@/components/FinanceChart'
 import PieChart from '@/components/PieChart'
 import records from './mockup.json'
+import { useState } from 'react'
 
 export const metadata = {
   title: 'Entrate e Uscite',
 }
 
 export default function EntrateUscitePage() {
+  const [summary, setSummary] = useState({ entrate: 0, uscite: 0, totale: 0 })
   return (
     <div className="bilancio">
       <h1 className="title">Entrate/Uscite</h1>
-      <FinanceChart records={records} />
+      <FinanceChart records={records} onSummary={setSummary} />
+      <p className="totals">
+        USCITE: {summary.uscite}€&nbsp; ENTRATE: {summary.entrate}€&nbsp; TOTALE:{' '}
+        {summary.totale}€
+      </p>
       <div className="pie-charts">
         <PieChart records={records} type="entrata" title="Entrate per mese" />
         <PieChart records={records} type="uscita" title="Uscite per mese" />

--- a/app/styles/finanze.css
+++ b/app/styles/finanze.css
@@ -63,10 +63,24 @@
   border-radius: 0 0 4px 4px;
 }
 
-.bar-label {
-  margin-top: 0.25rem;
-  font-size: 0.8rem;
-  text-align: center;
+
+@keyframes vibrate {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-1px);
+  }
+  75% {
+    transform: translateX(1px);
+  }
+}
+
+.bar:hover .bar-inner {
+  transform: scale(1.1);
+  animation: vibrate 0.3s linear infinite;
+  box-shadow: 0 0 8px var(--color-primary);
 }
 
 .bar-tooltip {
@@ -95,24 +109,22 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
 }
 
-.pie-legend {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
+.pie-tooltip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--background);
+  color: var(--foreground);
+  border: 1px solid var(--color-primary);
+  padding: 0 0.25rem;
+  border-radius: 4px;
   font-size: 0.75rem;
-  gap: 0.25rem;
-}
-
-.pie-legend .color-box {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  margin-right: 0.25rem;
-  border-radius: 2px;
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .pie-chart {
@@ -124,6 +136,21 @@
   height: 120px;
   border-radius: 50%;
   border: 1px solid var(--foreground);
+  overflow: visible;
+}
+
+.pie-chart path {
+  transition: transform 0.3s ease;
+}
+
+.pie-chart path:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(0 0 5px var(--color-primary));
+}
+
+.totals {
+  font-size: 0.9rem;
+  margin: 0.5rem 0;
 }
 
 @media (max-width: 480px) {

--- a/components/FinanceChart.js
+++ b/components/FinanceChart.js
@@ -1,7 +1,8 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 const months = [
+  'Tutti',
   'Gennaio',
   'Febbraio',
   'Marzo',
@@ -16,12 +17,32 @@ const months = [
   'Dicembre',
 ]
 
-export default function FinanceChart({ records = [] }) {
+export default function FinanceChart({ records = [], onSummary }) {
   const [monthIdx, setMonthIdx] = useState(0)
   const [hoverIdx, setHoverIdx] = useState(null)
   const currentMonth = months[monthIdx]
-  const filtered = records.filter(r => r.mese === currentMonth)
+  const filtered =
+    currentMonth === 'Tutti'
+      ? [...records]
+      : records.filter(r => r.mese === currentMonth)
+  filtered.sort((a, b) => new Date(a.data) - new Date(b.data))
   const max = Math.max(...filtered.map(r => r.importo), 1)
+
+  const totalEntrate = filtered
+    .filter(r => r.tipo === 'entrata')
+    .reduce((s, r) => s + r.importo, 0)
+  const totalUscite = filtered
+    .filter(r => r.tipo === 'uscita')
+    .reduce((s, r) => s + r.importo, 0)
+
+  useEffect(() => {
+    onSummary?.({
+      month: currentMonth,
+      entrate: totalEntrate,
+      uscite: totalUscite,
+      totale: totalEntrate - totalUscite,
+    })
+  }, [monthIdx, records])
 
   return (
     <div className="finance-chart">
@@ -58,9 +79,14 @@ export default function FinanceChart({ records = [] }) {
             >
               <div className="bar-inner" style={{ '--h': height }} />
               {isHover && (
-                <span className="bar-tooltip">{rec.importo}€</span>
+                <span className="bar-tooltip">
+                  {rec.descrizione}
+                  <br />
+                  {rec.importo}€
+                  <br />
+                  {rec.data}
+                </span>
               )}
-              <small className="bar-label">{rec.descrizione}</small>
             </div>
           )
         })}

--- a/components/PieChart.js
+++ b/components/PieChart.js
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { useState } from 'react'
 
 const months = [
   'Gennaio',
@@ -16,11 +16,11 @@ const months = [
   'Dicembre',
 ]
 
-const colors = Array.from({ length: 12 }, (_, i) =>
-  `hsl(130, 70%, ${35 + i * 3}%)`
-)
+const colors = ['var(--color-primary)', 'var(--color-white)']
 
 export default function PieChart({ records = [], type = 'entrata', title }) {
+  const [hoverIdx, setHoverIdx] = useState(null)
+
   const totals = months.map(m =>
     records
       .filter(r => r.mese === m && r.tipo === type)
@@ -30,37 +30,53 @@ export default function PieChart({ records = [], type = 'entrata', title }) {
 
   let startDeg = 0
   const segments = totals.map((t, i) => {
-    const pct = totalSum ? (t / totalSum) * 360 : 0
-    const end = startDeg + pct
-    const segment = `${colors[i % colors.length]} ${startDeg}deg ${end}deg`
+    const pct = totalSum ? t / totalSum : 0
+    const end = startDeg + pct * 360
+    const mid = startDeg + (pct * 360) / 2
     startDeg = end
-    return segment
+    return {
+      start: startDeg - pct * 360,
+      end,
+      mid,
+      color: colors[i % colors.length],
+      percent: Math.round(pct * 100),
+      label: months[i].slice(0, 3),
+    }
   })
-  const gradient = segments.length
-    ? `conic-gradient(${segments.join(',')})`
-    : 'none'
 
-  const percents = totals.map(t =>
-    totalSum ? Math.round((t / totalSum) * 100) : 0
-  )
+  const describeArc = (x, y, r, startAngle, endAngle) => {
+    const start = polar(x, y, r, endAngle)
+    const end = polar(x, y, r, startAngle)
+    const large = endAngle - startAngle > 180 ? 1 : 0
+    return `M ${x} ${y} L ${start.x} ${start.y} A ${r} ${r} 0 ${large} 0 ${end.x} ${end.y} Z`
+  }
+
+  const polar = (cx, cy, r, deg) => {
+    const rad = ((deg - 90) * Math.PI) / 180
+    return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) }
+  }
 
   return (
     <div className="pie-wrapper">
       {title && <h2 className="subtitle">{title}</h2>}
-      <div className="pie-chart" style={{ background: gradient }} />
-      <ul className="pie-legend">
-        {percents.map((p, i) =>
-          p > 0 ? (
-            <li key={i}>
-              <span
-                className="color-box"
-                style={{ background: colors[i % colors.length] }}
-              />
-              {months[i].slice(0, 3)} {p}%
-            </li>
-          ) : null
-        )}
-      </ul>
+      <svg viewBox="0 0 100 100" className="pie-chart">
+        {segments.map((seg, i) => (
+          seg.percent > 0 && (
+            <path
+              key={i}
+              d={describeArc(50, 50, 50, seg.start, seg.end)}
+              fill={seg.color}
+              onMouseEnter={() => setHoverIdx(i)}
+              onMouseLeave={() => setHoverIdx(null)}
+            />
+          )
+        ))}
+      </svg>
+      {hoverIdx !== null && (
+        <div className="pie-tooltip">
+          {segments[hoverIdx].label} {segments[hoverIdx].percent}%
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expand finance dataset with dates and extra entries
- add aggregate totals and 'Tutti' filter to FinanceChart
- animate bar hover and show details in tooltip
- redesign PieChart with alternating colors and tooltips
- display totals under the chart

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704b90d5e8832fa2b7e2db9887acba