### PR TITLE
Fix entrate-uscite page build error

### DIFF
--- a/app/entrate-uscite/page.js
+++ b/app/entrate-uscite/page.js
@@ -1,3 +1,5 @@
+'use client'
+
 import FinanceChart from '@/components/FinanceChart'
 import PieChart from '@/components/PieChart'
 import records from './mockup.json'


### PR DESCRIPTION
## Summary
- mark `app/entrate-uscite/page.js` as a client component so React hooks can be used

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704d3a8a5c832fa97fa771c0f52d8d