### PR TITLE
Fix build by removing metadata from client page

### DIFF
--- a/app/entrate-uscite/page.js
+++ b/app/entrate-uscite/page.js
@@ -5,10 +5,6 @@ import PieChart from '@/components/PieChart'
 import records from './mockup.json'
 import { useState } from 'react'
 
-export const metadata = {
-  title: 'Entrate e Uscite',
-}
-
 export default function EntrateUscitePage() {
   const [summary, setSummary] = useState({ entrate: 0, uscite: 0, totale: 0 })
   return (


### PR DESCRIPTION
## Summary
- remove `metadata` export from `app/entrate-uscite/page.js` since it's a client component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704ea2ddd0832fadd4a3272f026791