### PR TITLE
Add Spesatore budget tool

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -11,6 +11,7 @@ import "./styles/game.css";
 import "./styles/magazzino.css";
 import "./styles/about.css";
 import "./styles/finanze.css";
+import "./styles/spesatore.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import AuthProvider from "@/components/AuthProvider";
@@ -50,6 +51,7 @@ export default function RootLayout({ children }) {
               { label: 'Game', href: '/game' },
               { label: 'Magazzino', href: '/magazzino' },
               { label: 'Entrate/Uscite', href: '/entrate-uscite' },
+              { label: 'Spesatore', href: '/spesatore' },
             ]}
           />
           {children}

--- a/app/spesatore/mockup.json
+++ b/app/spesatore/mockup.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Base",
+    "items": [
+      { "type": "expense", "description": "Affitto", "amount": 1000, "frequency": "monthly" },
+      { "type": "expense", "description": "Marketing", "amount": 500, "frequency": "monthly" },
+      { "type": "income", "description": "Vendite", "amount": 3000, "frequency": "monthly" }
+    ]
+  }
+]

--- a/app/spesatore/page.js
+++ b/app/spesatore/page.js
@@ -1,0 +1,15 @@
+import Spesatore from '@/components/Spesatore'
+import configs from './mockup.json'
+
+export const metadata = {
+  title: 'Spesatore'
+}
+
+export default function SpesatorePage() {
+  return (
+    <div className="spesatore">
+      <h1 className="title">Spesatore</h1>
+      <Spesatore configs={configs} />
+    </div>
+  )
+}

--- a/app/styles/spesatore.css
+++ b/app/styles/spesatore.css
@@ -1,0 +1,46 @@
+.spesatore {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 0;
+  min-height: calc(100vh - 120px);
+}
+
+.spesatore-tool {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.config-select {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.config-name input {
+  width: 100%;
+}
+
+.items {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.items th,
+.items td {
+  border: 1px solid var(--color-primary);
+  padding: 0.25rem;
+}
+
+.add-item {
+  align-self: flex-start;
+}
+
+.summary {
+  font-weight: bold;
+  margin-top: 0.5rem;
+}

--- a/components/Spesatore.js
+++ b/components/Spesatore.js
@@ -1,0 +1,107 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export default function Spesatore({ configs: initial }) {
+  const [configs, setConfigs] = useState(initial)
+  const [currentIdx, setCurrentIdx] = useState(0)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('spesatoreConfigs')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (Array.isArray(parsed)) setConfigs(parsed)
+      } catch {}
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('spesatoreConfigs', JSON.stringify(configs))
+  }, [configs])
+
+  const current = configs[currentIdx]
+
+  const addConfig = () => {
+    setConfigs([...configs, { name: 'Nuova', items: [] }])
+    setCurrentIdx(configs.length)
+  }
+
+  const renameConfig = name => {
+    const copy = [...configs]
+    copy[currentIdx].name = name
+    setConfigs(copy)
+  }
+
+  const addItem = () => {
+    const copy = [...configs]
+    copy[currentIdx].items.push({
+      type: 'expense',
+      description: '',
+      amount: 0,
+      frequency: 'once',
+    })
+    setConfigs(copy)
+  }
+
+  const updateItem = (idx, field, value) => {
+    const copy = [...configs]
+    copy[currentIdx].items[idx][field] = value
+    setConfigs(copy)
+  }
+
+  const total = current.items.reduce((sum, it) => {
+    const mult = it.frequency === 'monthly' ? 12 : it.frequency === 'weekly' ? 52 : 1
+    const sign = it.type === 'income' ? 1 : -1
+    return sum + it.amount * mult * sign
+  }, 0)
+
+  return (
+    <div className="spesatore-tool">
+      <div className="config-select">
+        <select value={currentIdx} onChange={e => setCurrentIdx(Number(e.target.value))}>
+          {configs.map((c, i) => (
+            <option key={i} value={i}>{c.name}</option>
+          ))}
+        </select>
+        <button onClick={addConfig} className="btn">Nuova Configurazione</button>
+      </div>
+      <div className="config-name">
+        <input value={current.name} onChange={e => renameConfig(e.target.value)} />
+      </div>
+      <table className="items">
+        <thead>
+          <tr>
+            <th>Tipo</th><th>Descrizione</th><th>Frequenza</th><th>Importo</th>
+          </tr>
+        </thead>
+        <tbody>
+          {current.items.map((it, idx) => (
+            <tr key={idx}>
+              <td>
+                <select value={it.type} onChange={e => updateItem(idx, 'type', e.target.value)}>
+                  <option value="income">Entrata</option>
+                  <option value="expense">Uscita</option>
+                </select>
+              </td>
+              <td>
+                <input value={it.description} onChange={e => updateItem(idx, 'description', e.target.value)} />
+              </td>
+              <td>
+                <select value={it.frequency} onChange={e => updateItem(idx, 'frequency', e.target.value)}>
+                  <option value="once">Una Tantum</option>
+                  <option value="monthly">Mensile</option>
+                  <option value="weekly">Settimanale</option>
+                </select>
+              </td>
+              <td>
+                <input type="number" value={it.amount} onChange={e => updateItem(idx, 'amount', Number(e.target.value))} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button onClick={addItem} className="btn add-item">+ Aggiungi Voce</button>
+      <div className="summary">Previsione annuale: {total}€</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `Spesatore` component
- add `/spesatore` page with example data
- import new styles and page link in layout
- style the new page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687050109c7c832fb183d688eaa79485