### PR TITLE
Adjust finance chart size and display labels

### DIFF
--- a/app/styles/finanze.css
+++ b/app/styles/finanze.css
@@ -9,7 +9,7 @@
 
 .finance-chart {
   width: 100%;
-  max-width: 600px;
+  max-width: none;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -20,8 +20,9 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  height: 200px;
-  overflow-x: auto;
+  height: 400px;
+  padding: 2rem 0;
+  overflow: hidden;
 }
 
 .chart::before {
@@ -36,8 +37,8 @@
 
 .bar {
   position: relative;
-  flex: none;
-  width: 32px;
+  flex: 1;
+  min-width: 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -95,6 +96,19 @@
   font-size: 0.75rem;
   white-space: nowrap;
   pointer-events: none;
+}
+
+.bar-label {
+  position: absolute;
+  bottom: calc(50% + var(--h, 0));
+  transform: translateY(-0.25rem);
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
+.bar.expense .bar-label {
+  bottom: calc(50% - var(--h, 0));
+  transform: translateY(calc(-100% - 0.25rem));
 }
 
 .pie-charts {

--- a/components/FinanceChart.js
+++ b/components/FinanceChart.js
@@ -78,6 +78,7 @@ export default function FinanceChart({ records = [], onSummary }) {
               onMouseLeave={() => setHoverIdx(null)}
             >
               <div className="bar-inner" style={{ '--h': height }} />
+              <span className="bar-label">{rec.importo}€</span>
               {isHover && (
                 <span className="bar-tooltip">
                   {rec.descrizione}


### PR DESCRIPTION
## Summary
- expand the FinanceChart to take the full page width
- increase vertical space and remove internal scrollbars
- allow bars to shrink and show amount labels

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687050a03060832fa51fd2508b74fd59